### PR TITLE
Updated to work with Python3 and ignore BOM

### DIFF
--- a/takoboto2anki.py
+++ b/takoboto2anki.py
@@ -10,6 +10,7 @@ deck_lists = {
         'takoboto3': [u'東京2', u'東京3']
         }
 
+
 def make_list2deck():
     list2deck = {}
     for deck in deck_lists:
@@ -21,17 +22,17 @@ def make_list2deck():
 
 
 def process_csv(filename, list2deck):
-    with open(filename) as tcsv:
+    with open(filename, encoding='utf-8-sig') as tcsv:
         for line in reader(tcsv):
-            list_name = unicode(line[0], 'utf-8')
+            list_name = str(line[0])
             if list_name in list2deck:
-                with open(list2deck[list_name] + '.txt', 'a') as txt:
+                with open(list2deck[list_name] + '.txt', 'a', encoding='utf-8-sig') as txt:
                    txt.write(create_ankiline(line))
 
 def create_ankiline(line):
     jap = line[3].split(', , ')[0]
     trans = line[4]
-    trans = string.replace(trans, ', , ', '<br><br>')
+    trans = trans.replace(', , ', '<br><br>')
     return jap + ';' + trans + '\n'
 
 


### PR DESCRIPTION
My friend couldn't use the integrated "export to anki" option in Takoboto for some reason. Tried first using "export to file" then converting to Anki through your script but had a couple of issues - Python3 works a bit differently and the files had Byte Order Marks right next to the fields, which caused "UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 87: character maps to <undefined>". Also, string.<something> isn't used anymore so changed that a bit.

Don't know if anyone will use this script in the future but it should work on Python3 now - checked it with two different files (my friend's and the one I exported myself for testing)